### PR TITLE
Precompiled release binaries w/ and w/o vector support

### DIFF
--- a/.github/workflows/publish_release_binaries.yaml
+++ b/.github/workflows/publish_release_binaries.yaml
@@ -20,16 +20,35 @@ jobs:
         echo "build-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
         echo "bin-dir=${{ github.workspace }}/bin" >> "$GITHUB_OUTPUT"
 
-    - name: Configure CMake
+    - name: Configure CMake (w/ vector support)
       run: >
         cmake -B ${{ steps.strings.outputs.build-dir }}
         -DQUICKED_NONATIVE=ON
         -S ${{ github.workspace }}
 
-    - name: Build
+    - name: Build (w/ vector support)
       run: cmake --build ${{ steps.strings.outputs.build-dir }} --config Release --parallel 2
 
-    - name: Move the target artifacts
+    - name: Move the target artifacts (w/ vector support)
+      run: |
+        mkdir -p ${{ steps.strings.outputs.bin-dir }}/release
+        mv ${{ steps.strings.outputs.bin-dir }}/align_benchmark ${{ steps.strings.outputs.bin-dir }}/release/align_benchmark-x86_64-SIMD
+        mv ${{ steps.strings.outputs.bin-dir }}/generate_dataset ${{ steps.strings.outputs.bin-dir }}/release/generate_dataset-x86_64-SIMD
+
+    - name: Clean
+      run: cmake --build ${{ steps.strings.outputs.build-dir }} --target clean
+
+    - name: Configure CMake (w/o vector support)
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-dir }}
+        -DQUICKED_NONATIVE=ON
+        -DQUICKED_FORCESCALAR=ON
+        -S ${{ github.workspace }}
+
+    - name: Build (w/o vector support)
+      run: cmake --build ${{ steps.strings.outputs.build-dir }} --config Release --parallel 2
+
+    - name: Move the target artifacts (w/o vector support)
       run: |
         mkdir -p ${{ steps.strings.outputs.bin-dir }}/release
         mv ${{ steps.strings.outputs.bin-dir }}/align_benchmark ${{ steps.strings.outputs.bin-dir }}/release/align_benchmark-x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ enable_testing()
 
 # Options
 option(QUICKED_NONATIVE "Compile QuickEd for generic x86_64" OFF)
+option(QUICKED_FORCESCALAR "Compile QuickEd without vector extensions (SSE,AVX)" OFF)
 
 # Set build type to Release if not specified
 if (NOT CMAKE_BUILD_TYPE)
@@ -61,7 +62,10 @@ add_compile_options(-fPIC)
 if (NOT QUICKED_NONATIVE)
     add_compile_options(-march=native)
 else()
-    add_compile_options(-march=x86-64 -msse4.1)
+    add_compile_options(-march=x86-64)
+    if (NOT QUICKED_FORCESCALAR)
+        add_compile_options(-msse4.1 -mavx2)
+    endif()
 endif()
 
 # Output directories


### PR DESCRIPTION
Now, we support building x86-64 binaries with and without vector support through CMake flags.
The release CI flow uses both configurations so that releases offer both precompiled versions.